### PR TITLE
Fix core->notifyDataAdded calls in HDF5_10X and HDF5 TOME_Loader

### DIFF
--- a/src/HDF5_10X_Loader.cpp
+++ b/src/HDF5_10X_Loader.cpp
@@ -151,11 +151,15 @@ PointsPlugin * HDF5_10X_Loader::open(const QString &fileName, int conversionInde
 		QString dataSetName = QInputDialog::getText(nullptr, "Add New Dataset",
 			"Dataset name:", QLineEdit::Normal, "DataSet", &ok);
 
-		if (ok && !dataSetName.isEmpty()) {
-			QString name = _core->addData("Points", dataSetName);
-			const IndexSet& set = dynamic_cast<const IndexSet&>(_core->requestSet(name));
-			pointsPlugin = &(set.getData());
+		if (!ok || dataSetName.isEmpty())
+		{
+			return nullptr;
 		}
+		
+		const QString name = _core->addData("Points", dataSetName);
+		const IndexSet& set = dynamic_cast<const IndexSet&>(_core->requestSet(name));
+		pointsPlugin = &(set.getData());
+
 		if (pointsPlugin == nullptr)
 			return nullptr;
 		QGuiApplication::setOverrideCursor(Qt::WaitCursor);
@@ -164,7 +168,7 @@ PointsPlugin * HDF5_10X_Loader::open(const QString &fileName, int conversionInde
 		HDF5_10X::loadFromFile(fileName.toStdString(), rawData, speedIndex, conversionIndex);
 
 
-		_core->notifyDataAdded(pointsPlugin->getName());
+		_core->notifyDataAdded(name);
 	}
 	catch (std::exception &e)
 	{

--- a/src/HDF5_TOME_Loader.cpp
+++ b/src/HDF5_TOME_Loader.cpp
@@ -298,11 +298,15 @@ PointsPlugin *HDF5_TOME_Loader::open(const QString &fileName, int conversionInde
 		QString dataSetName = QInputDialog::getText(nullptr, "Add New Dataset",
 			"Dataset name:", QLineEdit::Normal, "DataSet", &ok);
 
-		if (ok && !dataSetName.isEmpty()) {
-			QString name = _core->addData("Points", dataSetName);
-			const IndexSet& set = dynamic_cast<const IndexSet&>(_core->requestSet(name));
-			pointsPlugin = &(set.getData());
+		if (!ok || dataSetName.isEmpty())
+		{
+			return nullptr;
 		}
+
+		const QString name = _core->addData("Points", dataSetName);
+		const IndexSet& set = dynamic_cast<const IndexSet&>(_core->requestSet(name));
+		pointsPlugin = &(set.getData());
+
 		if (pointsPlugin == nullptr)
 			return nullptr;
 
@@ -359,7 +363,7 @@ PointsPlugin *HDF5_TOME_Loader::open(const QString &fileName, int conversionInde
 // 		}
 
 
-		_core->notifyDataAdded(pointsPlugin->getName());
+		_core->notifyDataAdded(name);
 		QGuiApplication::restoreOverrideCursor();
 		return pointsPlugin;
 	}


### PR DESCRIPTION
Fixes "Failed to find a set with name: Points{...}" messages from `hdps::Core::requestSet`, when image data is loaded after having opened tSNE Analysis.

Discussed with Jeroen @jeggermont and @JulianThijssen