### PR TITLE
Fix memory leaks from HDF5Loader data members

### DIFF
--- a/src/HDF5Loader.h
+++ b/src/HDF5Loader.h
@@ -2,7 +2,7 @@
 
 #include <LoaderPlugin.h>
 
-#include <QString>
+#include <QObject>
 
 using namespace hdps::plugin;
 
@@ -10,12 +10,6 @@ using namespace hdps::plugin;
 // View
 // =============================================================================
 
-
-class QFileDialog;
-class QComboBox;
-class QCheckBox;
-
-class QLabel;
 
 class HDF5Loader : public QObject, public LoaderPlugin
 {
@@ -27,11 +21,4 @@ public:
 
     void loadData() Q_DECL_OVERRIDE;
 
-private:
-    QString _fileName;
-	QFileDialog *_openFileDialog;
-	QComboBox *_conversionCombo;
-	QCheckBox *_normalizeCheck;
-	QLabel *_normalizeLabel;
-	
 };


### PR DESCRIPTION
All five data members of HDF5Loader were leaking:

	QString _fileName;
	QFileDialog *_openFileDialog;
	QComboBox *_conversionCombo;
	QCheckBox *_normalizeCheck;
	QLabel *_normalizeLabel;

This pull request fixes these memory leaks by declaring them as local variables within `HDF5Loader::loadData()`.

It also replaces an old-style string-based signal-slot connect by a modern (Qt 5) functor-based connect, just to ease fixing the memory leaks. 
