### PR TITLE
Remove deprecated Points::operator[] calls from HDF5Loader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ source_group( Plugin FILES ${SOURCES})
 
 add_library(${PROJECT} SHARED ${SOURCES})
 
+target_compile_definitions(${PROJECT} PRIVATE BIOVAULT_BFLOAT16_CONVERTING_CONSTRUCTORS)
 target_link_libraries(${PROJECT} Qt5::Widgets)
 target_link_libraries(${PROJECT} Qt5::WebEngineWidgets)
 target_link_libraries(${PROJECT} "$ENV{HDPS_INSTALL_DIR}/$<CONFIGURATION>/lib/HDPS_Public.lib")

--- a/src/DataContainerInterface.cpp
+++ b/src/DataContainerInterface.cpp
@@ -12,6 +12,7 @@
 #include <QGridLayout>
 #include <QLabel>
 #include <QString>
+#include <stdexcept> // For std::out_of_range.
 
 
 
@@ -37,115 +38,124 @@ void DataContainerInterface::set_sparse_row_data(std::vector<uint64_t> &column_i
 {
 	long long lrows = ((long long)m_data->getNumPoints());
 	auto columns = m_data->getNumDimensions();
-#pragma omp parallel for
-	for (long long row = 0; row < lrows; ++row)
-	{
-		uint32_t start = row_offset[row];
-		uint32_t end = row_offset[row + 1];
-		uint64_t points_offset = row * columns;
-
-		for (uint64_t i = start; i < end; ++i)
+	m_data->visitFromBeginToEnd([&column_index, &row_offset, &data, transformType, lrows, columns](const auto beginOfData, const auto endOfData)
 		{
-			float value = data[i];
-			uint64_t column = column_index[i];
-			if (value != 0)
+#pragma omp parallel for
+			for (long long row = 0; row < lrows; ++row)
 			{
-				switch (transformType)
+				uint32_t start = row_offset[row];
+				uint32_t end = row_offset[row + 1];
+				uint64_t points_offset = row * columns;
+
+				for (uint64_t i = start; i < end; ++i)
 				{
-				case TRANSFORM::NONE: (*m_data)[points_offset + column] = value; break;
-				case TRANSFORM::LOG:  (*m_data)[points_offset + column] =  log2(1 + value); break;
-				case TRANSFORM::ARCSIN5: (*m_data)[points_offset + column] =  asinh(value / 5.0); break;
-				case TRANSFORM::SQRT: (*m_data)[points_offset + column] = sqrt(value); break;
-				
+					float value = data[i];
+					uint64_t column = column_index[i];
+					if (value != 0)
+					{
+						switch (transformType)
+						{
+						case TRANSFORM::NONE: beginOfData[points_offset + column] = value; break;
+						case TRANSFORM::LOG:  beginOfData[points_offset + column] =  log2(1 + value); break;
+						case TRANSFORM::ARCSIN5: beginOfData[points_offset + column] =  asinh(value / 5.0); break;
+						case TRANSFORM::SQRT: beginOfData[points_offset + column] = sqrt(value); break;
+						}
+					}
 				}
 			}
-		}
-
-	}
+		});
 }
 
 void DataContainerInterface::increase_sparse_row_data(std::vector<uint64_t> &column_index, std::vector<uint32_t> &row_offset, std::vector<float> &data, TRANSFORM::Type transformType)
 {
 	long long lrows = ((long long)m_data->getNumPoints());
 	auto columns = m_data->getNumDimensions();
-#pragma omp parallel for
-	for (long long row = 0; row < lrows; ++row)
-	{
-		uint32_t start = row_offset[row];
-		uint32_t end = row_offset[row + 1];
-		uint64_t points_offset = row * columns;
-
-		for (uint64_t i = start; i < end; ++i)
+	m_data->visitFromBeginToEnd([&column_index, &row_offset, &data, transformType, lrows, columns](const auto beginOfData, const auto endOfData)
 		{
-			float value = data[i];
-			uint64_t column = column_index[i];
-			if (value != 0)
+#pragma omp parallel for
+			for (long long row = 0; row < lrows; ++row)
 			{
-				switch (transformType)
+				uint32_t start = row_offset[row];
+				uint32_t end = row_offset[row + 1];
+				uint64_t points_offset = row * columns;
+
+				for (uint64_t i = start; i < end; ++i)
 				{
-				case TRANSFORM::NONE: (*m_data)[points_offset + column] += value; break;
-				case TRANSFORM::LOG:  (*m_data)[points_offset + column] += log2(1 + value); break;
-				case TRANSFORM::ARCSIN5: (*m_data)[points_offset + column] += asinh(value / 5.0); break;
-				case TRANSFORM::SQRT: (*m_data)[points_offset + column] += sqrt(value); break;
+					float value = data[i];
+					uint64_t column = column_index[i];
+					if (value != 0)
+					{
+						switch (transformType)
+						{
+						case TRANSFORM::NONE: beginOfData[points_offset + column] += value; break;
+						case TRANSFORM::LOG:  beginOfData[points_offset + column] += log2(1 + value); break;
+						case TRANSFORM::ARCSIN5: beginOfData[points_offset + column] += asinh(value / 5.0); break;
+						case TRANSFORM::SQRT: beginOfData[points_offset + column] += sqrt(value); break;
+						}
+					}
 				}
 			}
-		}
-
-	}
+		});
 }
 
 void DataContainerInterface::set_sparse_column_data(std::vector<uint64_t> &row_index, std::vector<uint32_t> &column_offset, std::vector<float> &data, TRANSFORM::Type transformType /*= TRANSFORM::NONE*/)
 {
 	auto columns = m_data->getNumDimensions();
-#pragma  omp parallel for
-	for (long long column = 0; column < columns; ++column)
-	{
-		uint32_t start = column_offset[column];
-		uint32_t end = column_offset[column + 1];
-		for (uint32_t i = start; i < end; ++i)
+	m_data->visitFromBeginToEnd([&column_offset, &row_index, &data, transformType, columns](const auto beginOfData, const auto endOfData)
 		{
-			uint32_t r = row_index[i];
-			float value = data[i];
-			if (value != 0)
+#pragma  omp parallel for
+			for (long long column = 0; column < columns; ++column)
 			{
-				switch (transformType)
+				uint32_t start = column_offset[column];
+				uint32_t end = column_offset[column + 1];
+				for (uint32_t i = start; i < end; ++i)
 				{
-				case TRANSFORM::NONE: (*m_data)[(r*columns) + column] = value; break;
-				case TRANSFORM::LOG:  (*m_data)[(r*columns) + column] = log2(1 + value); break;
-				case TRANSFORM::ARCSIN5:(*m_data)[(r*columns) + column] = asinh(value / 5.0); break;
-				case TRANSFORM::SQRT: (*m_data)[(r*columns) + column] = sqrt(value); break;
+					uint32_t r = row_index[i];
+					float value = data[i];
+					if (value != 0)
+					{
+						switch (transformType)
+						{
+						case TRANSFORM::NONE: beginOfData[(r*columns) + column] = value; break;
+						case TRANSFORM::LOG:  beginOfData[(r*columns) + column] = log2(1 + value); break;
+						case TRANSFORM::ARCSIN5:beginOfData[(r*columns) + column] = asinh(value / 5.0); break;
+						case TRANSFORM::SQRT: beginOfData[(r*columns) + column] = sqrt(value); break;
+						}
+					}
 				}
 			}
-		}
-	}
+		});
 }
 
 void DataContainerInterface::increase_sparse_column_data(std::vector<uint64_t> &row_index, std::vector<uint32_t> &column_offset, std::vector<float> &data, TRANSFORM::Type transformType /*= TRANSFORM::NONE*/)
 
 {
 	auto columns = m_data->getNumDimensions();
-#pragma  omp parallel for
-	for (long long column = 0; column < columns; ++column)
-	{
-		uint32_t start = column_offset[column];
-		uint32_t end = column_offset[column + 1];
-		for (uint32_t i = start; i < end; ++i)
+	m_data->visitFromBeginToEnd([&row_index, &column_offset, &data, transformType, columns](const auto beginOfData, const auto endOfData)
 		{
-			uint32_t r = row_index[i];
-			float value = data[i];
-			if (value != 0)
+#pragma  omp parallel for
+			for (long long column = 0; column < columns; ++column)
 			{
-				switch (transformType)
+				uint32_t start = column_offset[column];
+				uint32_t end = column_offset[column + 1];
+				for (uint32_t i = start; i < end; ++i)
 				{
-				case TRANSFORM::NONE: (*m_data)[(r*columns) + column] += value; break;
-				case TRANSFORM::LOG:  (*m_data)[(r*columns) + column] += log2(1 + value); break;
-				case TRANSFORM::ARCSIN5:(*m_data)[(r*columns) + column] += asinh(value / 5.0); break;
-				case TRANSFORM::SQRT: (*m_data)[(r*columns) + column] += sqrt(value); break;
-				
+					uint32_t r = row_index[i];
+					float value = data[i];
+					if (value != 0)
+					{
+						switch (transformType)
+						{
+						case TRANSFORM::NONE: beginOfData[(r*columns) + column] += value; break;
+						case TRANSFORM::LOG:  beginOfData[(r*columns) + column] += log2(1 + value); break;
+						case TRANSFORM::ARCSIN5:beginOfData[(r*columns) + column] += asinh(value / 5.0); break;
+						case TRANSFORM::SQRT: beginOfData[(r*columns) + column] += sqrt(value); break;
+
+						}
+					}
 				}
 			}
-		}
-	}
+		});
 }
 
 void DataContainerInterface::applyTransform(TRANSFORM::Type transformType, bool normalized_and_cpm)
@@ -154,29 +164,32 @@ void DataContainerInterface::applyTransform(TRANSFORM::Type transformType, bool 
 	const auto columns = m_data->getNumDimensions();
 	if ((transformType == TRANSFORM::NONE) && !normalized_and_cpm)
 		return;
-	#pragma omp parallel for
-	for (std::int64_t row = 0; row < rows; ++row)
-	{
-		uint64_t offset = row * columns;
-		float *rowdata = &((*m_data)[offset]);
-		double dummy = 0.0;
-		double sum = std::accumulate(rowdata, rowdata + columns, dummy);
-		for (float *i = rowdata; i != rowdata + columns; ++i)
+	m_data->visitFromBeginToEnd([transformType, rows, columns](const auto beginOfData, const auto endOfData)
 		{
-			const DataValue value = *i;
-			if (value != 0)
+#pragma omp parallel for
+			for (std::int64_t row = 0; row < rows; ++row)
 			{
-				const DataValue normalized_cpm_value = (sum == 0) ? 0 : 1e6*(value / sum);
-				switch (transformType)
+				uint64_t offset = row * columns;
+				auto *rowdata = &(beginOfData[offset]);
+				double dummy = 0.0;
+				double sum = std::accumulate(rowdata, rowdata + columns, dummy);
+				for (auto *i = rowdata; i != rowdata + columns; ++i)
 				{
-				case TRANSFORM::NONE: *i = normalized_cpm_value; break;
-				case TRANSFORM::LOG: *i = log2(1 + normalized_cpm_value); break;
-				case TRANSFORM::ARCSIN5: *i = asinh(normalized_cpm_value / 5.0); break;
-				case TRANSFORM::SQRT: *i = sqrt(normalized_cpm_value); break;
+					const DataValue value = *i;
+					if (value != 0)
+					{
+						const DataValue normalized_cpm_value = (sum == 0) ? 0 : 1e6 * (value / sum);
+						switch (transformType)
+						{
+						case TRANSFORM::NONE: *i = normalized_cpm_value; break;
+						case TRANSFORM::LOG: *i = log2(1 + normalized_cpm_value); break;
+						case TRANSFORM::ARCSIN5: *i = asinh(normalized_cpm_value / 5.0); break;
+						case TRANSFORM::SQRT: *i = sqrt(normalized_cpm_value); break;
+						}
+					}
 				}
 			}
-		}
-	}
+		});
 }
 
 Points * DataContainerInterface::points()
@@ -186,7 +199,7 @@ Points * DataContainerInterface::points()
 
 void DataContainerInterface::set(RowID row, ColumnID column, const ValueType & value)
 {
-	(*m_data)[(row*m_data->getNumDimensions()) + column] = value;
+	m_data->setValueAt((row*m_data->getNumDimensions()) + column, value);
 }
 
 void DataContainerInterface::addRow(RowID row, const std::vector<uint32_t> &columns, const std::vector<float> &data, TRANSFORM::Type transformType)
@@ -196,22 +209,25 @@ void DataContainerInterface::addRow(RowID row, const std::vector<uint32_t> &colu
 		throw std::out_of_range("DataContainerInterface::addRow vectors have different sizes!");
 	
 	auto points_offset = row * m_data->getNumDimensions();
-	auto d = data.cbegin();
-	
-	for (auto i = columns.cbegin(); i != columns.cend(); ++i, ++d)
-	{
-		float value = *d;
-		auto column = *i;
-		
-		switch (transformType)
+	m_data->visitFromBeginToEnd([&columns, &data, transformType, points_offset](const auto beginOfData, const auto endOfData)
 		{
-		case TRANSFORM::NONE: (*m_data)[points_offset + column] = value; break;
-		case TRANSFORM::LOG:  (*m_data)[points_offset + column] = log2(1 + value); break;
-		case TRANSFORM::ARCSIN5: (*m_data)[points_offset + column] = asinh(value / 5.0); break;
-		case TRANSFORM::SQRT: (*m_data)[points_offset + column] = sqrt(value); break;
+			auto d = data.cbegin();
 
-		}		
-	}
+			for (auto i = columns.cbegin(); i != columns.cend(); ++i, ++d)
+			{
+				float value = *d;
+				auto column = *i;
+
+				switch (transformType)
+				{
+				case TRANSFORM::NONE: beginOfData[points_offset + column] = value; break;
+				case TRANSFORM::LOG:  beginOfData[points_offset + column] = log2(1 + value); break;
+				case TRANSFORM::ARCSIN5: beginOfData[points_offset + column] = asinh(value / 5.0); break;
+				case TRANSFORM::SQRT: beginOfData[points_offset + column] = sqrt(value); break;
+
+				}
+			}
+		});
 }
 
 void DataContainerInterface::add(std::vector<uint32_t> *rows, std::vector<uint32_t> *columns, std::vector<float> *data, TRANSFORM::Type transformType)
@@ -231,26 +247,26 @@ void DataContainerInterface::add(std::vector<uint32_t> *rows, std::vector<uint32
 		uint32_t end = (*rows)[row + 1];
 		std::uint64_t points_offset = row * m_data->getNumDimensions();
 
-		const float *data_ptr = data->data();
-		const float * d = data_ptr + start;
-		const uint32_t * column_ptr = columns->data();
-		for (const uint32_t *i = column_ptr + start; i != column_ptr + end; ++i, ++d)
-		{
-			float value = *d;
-			auto column = *i;
-			if (value != 0)
+		m_data->visitFromBeginToEnd([columns, data, transformType, start, end, points_offset](const auto beginOfData, const auto endOfData)
 			{
-				switch (transformType)
+				const float* data_ptr = data->data();
+				const float* d = data_ptr + start;
+				const uint32_t* column_ptr = columns->data();
+				for (const uint32_t* i = column_ptr + start; i != column_ptr + end; ++i, ++d)
 				{
-				case TRANSFORM::NONE: (*m_data)[points_offset + column] = value; break;
-				case TRANSFORM::LOG:  (*m_data)[points_offset + column] = log2(1 + value); break;
-				case TRANSFORM::ARCSIN5: (*m_data)[points_offset + column] = asinh(value / 5.0); break;
-				case TRANSFORM::SQRT: (*m_data)[points_offset + column] = sqrt(value); break;
-
+					float value = *d;
+					auto column = *i;
+					if (value != 0)
+					{
+						switch (transformType)
+						{
+						case TRANSFORM::NONE: beginOfData[points_offset + column] = value; break;
+						case TRANSFORM::LOG:  beginOfData[points_offset + column] = log2(1 + value); break;
+						case TRANSFORM::ARCSIN5: beginOfData[points_offset + column] = asinh(value / 5.0); break;
+						case TRANSFORM::SQRT: beginOfData[points_offset + column] = sqrt(value); break;
+						}
+					}
 				}
-			}
-				
-		}
-
+			});
 	}
 }


### PR DESCRIPTION
Replace `Points::operator[]` calls within DataContainerInterface.cpp by `Points::visitFromBeginToEnd`

Fixes warnings, introduced by HDPS core pull request #65 (Support bfloat16 and small integer types as data element type of PointData), which said:

> warning C4996: 'Points::operator []': Deprecated: Assumes that point data is always 32-bit float!

Allows supporting point data element types other than `float`.