### PR TITLE
Store experimental sparse data

### DIFF
--- a/src/DataContainerInterface.cpp
+++ b/src/DataContainerInterface.cpp
@@ -145,10 +145,8 @@ void DataContainerInterface::resize(RowID rows, ColumnID columns, std::size_t re
 			qDebug() << "Bad Allocation in setData: " << rows << " x " << columns;
 		}
 			
-			
-
-			qDebug() << "Number of dimensions: " << m_data->getNumDimensions();
-			qDebug() << "Number of data points: " << m_data->getNumPoints();		
+		qDebug() << "Number of dimensions: " << m_data->getNumDimensions();
+		qDebug() << "Number of data points: " << m_data->getNumPoints();		
 	}
 }
 

--- a/src/H5ADLoader.cpp
+++ b/src/H5ADLoader.cpp
@@ -74,7 +74,6 @@ namespace
 
 H5ADLoader::H5ADLoader(PluginFactory* factory)
     : LoaderPlugin(factory)
-	
 {
 	
 }
@@ -87,7 +86,6 @@ H5ADLoader::~H5ADLoader(void)
 
 void H5ADLoader::init()
 {
-	
 	QStringList fileTypeOptions;
 	fileTypeOptions.append("H5AD (*.h5ad)");
 	_fileDialog.setOption(QFileDialog::DontUseNativeDialog);
@@ -162,10 +160,9 @@ void H5ADLoader::loadData()
 		settings.setValue(Keys::storageValueKey,  storageTypeComboBox->currentIndex());
 		settings.setValue(Keys::fileNameKey, firstFileName);
 		settings.setValue(Keys::selectedNameFilterKey, selectedNameFilter);
-		
 
 		HDF5_AD_Loader loader(_core);
-		for (const auto fileName : fileNames)
+		for (const auto& fileName : fileNames)
 		{
 			if (loader.open(fileName))
 				loader.load(storageTypeComboBox->currentData().toInt());

--- a/src/H5ADLoader.h
+++ b/src/H5ADLoader.h
@@ -13,11 +13,6 @@ using namespace mv::plugin;
 
 class H5ADLoader :  public LoaderPlugin
 {
-	QFileDialog _fileDialog;
-	
-protected:
-	int _storageType;
-
 public:
 	
 	H5ADLoader(PluginFactory* factory);
@@ -26,5 +21,8 @@ public:
     void init() Q_DECL_OVERRIDE;
 
     void loadData() Q_DECL_OVERRIDE;
+
+private:
+	QFileDialog _fileDialog = QFileDialog{};
 
 };

--- a/src/H5ADUtils.cpp
+++ b/src/H5ADUtils.cpp
@@ -597,62 +597,117 @@ namespace H5AD
 		return std::string();
 	}
 
+	bool ContainsSparseMatrix(H5::Group& group)
+	{
+		bool hasData = H5Utils::contains_name(group, "data");
+		bool hasIndices = H5Utils::contains_name(group, "indices");
+		bool hasIndicesPtr = H5Utils::contains_name(group, "indptr");
+
+		return hasData && hasIndices && hasIndicesPtr;
+	}
+
 	bool LoadSparseMatrix(H5::Group& group, LoaderInfo &loaderInfo)
 	{
+		bool loadSuccess = false;
+
 		auto nrOfObjects = group.getNumObjs();
 		auto h5groupName = group.getObjName();
 
-		bool containsSparseMatrix = false;
-		if (nrOfObjects > 2)
-		{
-			H5Utils::VectorHolder data;
-			H5Utils::VectorHolder indices;
-			H5Utils::VectorHolder indptr;
+		if (nrOfObjects <= 2)
+			return loadSuccess;
 
-			containsSparseMatrix = H5Utils::read_vector(group, "data", data);
-			if (containsSparseMatrix)
-				containsSparseMatrix &= H5Utils::read_vector(group, "indices", indices);
-			if (containsSparseMatrix)
-				containsSparseMatrix &= H5Utils::read_vector(group, "indptr", indptr);
+		if (!ContainsSparseMatrix(group))
+			return loadSuccess;
 
-			if (containsSparseMatrix)
-			{
-				std::uint64_t xsize = indptr.size() > 0 ? indptr.size() - 1 : 0;
-				if (xsize == loaderInfo._pointsDataset->getNumPoints())
-				{
-					std::uint64_t ysize = indices.visit<std::uint64_t>([](auto& vec) { return *std::max_element(vec.cbegin(), vec.cend()); }) + 1;
+		H5Utils::VectorHolder data;
+		H5Utils::VectorHolder indices;
+		H5Utils::VectorHolder indptr;
 
-					std::vector<QString> dimensionNames(ysize);
-					for (std::size_t l = 0; l < ysize; ++l)
-						dimensionNames[l] = QString::number(l);
-					QString numericalDatasetName = QString(h5groupName.c_str()) /* + " (numerical)" */;
-					while (numericalDatasetName[0] == '/')
-						numericalDatasetName.remove(0, 1);
-					while (numericalDatasetName[0] == '\\')
-						numericalDatasetName.remove(0, 1);
-					Dataset<Points> numericalDataset = mv::data().createDerivedDataset(numericalDatasetName, loaderInfo._pointsDataset); // core->addDataset("Points", numericalDatasetName, parent);
-					numericalDataset->setProperty("Sample Names", loaderInfo._sampleNames);
-					data.visit([&numericalDataset](auto& vec) {
-						typedef typename std::decay_t<decltype(vec)> v;
-						numericalDataset->setDataElementType<typename v::value_type>();
-						});
+		bool readDataSuccess = H5Utils::read_vector(group, "data", data);
+		bool readIndicesSuccess = H5Utils::read_vector(group, "indices", indices);
+		bool readIndicesPtrSuccess = H5Utils::read_vector(group, "indptr", indptr);
 
+		if(!(readDataSuccess && readIndicesSuccess && readIndicesPtrSuccess))
+			return loadSuccess;
 
-					events().notifyDatasetAdded(numericalDataset);
-					DataContainerInterface dci(numericalDataset);
-					dci.resize(xsize, ysize);
-					dci.set_sparse_row_data(indices, indptr, data, TRANSFORM::None());
+		std::uint64_t xsize = indptr.size() > 0 ? indptr.size() - 1 : 0;
 
+		if(xsize != loaderInfo._pointsDataset->getNumPoints())
+			return loadSuccess;
 
-					numericalDataset->setDimensionNames(dimensionNames);
+		std::uint64_t ysize = indices.visit<std::uint64_t>([](auto& vec) { return *std::max_element(vec.cbegin(), vec.cend()); }) + 1;
 
-					events().notifyDatasetDataChanged(numericalDataset);
-					
-				}
+		// Data name
+		QString numericalDatasetName = QString(h5groupName.c_str()) /* + " (numerical)" */;
+		while (numericalDatasetName[0] == '/')
+			numericalDatasetName.remove(0, 1);
+		while (numericalDatasetName[0] == '\\')
+			numericalDatasetName.remove(0, 1);
+
+		// Create Dataset
+		Dataset<Points> numericalDataset = mv::data().createDerivedDataset(numericalDatasetName, loaderInfo._pointsDataset); // core->addDataset("Points", numericalDatasetName, parent);
+		numericalDataset->setProperty("Sample Names", loaderInfo._sampleNames);
+
+		data.visit([&numericalDataset](auto& vec) {
+			typedef typename std::decay_t<decltype(vec)> v;
+			numericalDataset->setDataElementType<typename v::value_type>();
+			});
+
+		auto exceedsXGigabytes = [](size_t length, size_t gigabytes = 4) -> bool{
+			constexpr size_t BYTES_PER_GB = 1024ll * 1024 * 1024;
+			const size_t maxBytes = gigabytes * BYTES_PER_GB;
+
+			// Get size of the type
+			const size_t elementSize = sizeof(float);
+
+			// Check for multiplication overflow
+			if (length > std::numeric_limits<size_t>::max() / elementSize) {
+				return true;
 			}
+
+			// Calculate total size and compare
+			const size_t totalBytes = length * elementSize;
+			return totalBytes > maxBytes;
+		};
+
+		if (exceedsXGigabytes(xsize * ysize, 4))
+		{
+			qDebug() << "H5AD loader: Store sparse data as sparse";
+
+			// Store sparse data as sparse
+			std::vector<float> data_float = data.getVectorAs<float>();
+			std::vector<size_t> column_index = indices.getVectorAs<size_t>();
+			std::vector<size_t> row_offset = indptr.getVectorAs<size_t>();
+
+			auto numericalDataset_p = static_cast<Points*>(numericalDataset.getDataset());
+
+			Points::Experimental::setSparseData(numericalDataset_p, xsize, ysize, std::move(column_index), std::move(row_offset), std::move(data_float));
+
+			// Experimental: other plugins cannot yet handle this sparse data
+			numericalDataset->lock();
+		}
+		else
+		{
+			qDebug() << "H5AD loader: Store sparse data as dense";
+
+			// Store sparse data as dense
+			DataContainerInterface dci(numericalDataset);
+			dci.resize(xsize, ysize);
+			dci.set_sparse_row_data(indices, indptr, data, TRANSFORM::None());
 		}
 
-		return containsSparseMatrix;
+		events().notifyDatasetDataChanged(numericalDataset);
+
+		// Dimension names
+		std::vector<QString> dimensionNames(ysize);
+		for (std::size_t l = 0; l < ysize; ++l)
+			dimensionNames[l] = QString::number(l);
+
+		numericalDataset->setDimensionNames(dimensionNames);
+
+		events().notifyDatasetDataChanged(numericalDataset);
+		
+		return loadSuccess;
 	}
 
 	bool LoadCategories(H5::Group& group, std::map<std::string, std::vector<QString>>& categories)
@@ -902,8 +957,10 @@ namespace H5AD
 
 		std::filesystem::path path(group.getObjName());
 		std::string h5GroupName = path.filename().string();
-		if (LoadSparseMatrix(group, loaderInfo))
+
+		if (ContainsSparseMatrix(group))
 		{
+			bool loadSparseSuccess = LoadSparseMatrix(group, loaderInfo);
 			return;
 		}
 			

--- a/src/H5ADUtils.cpp
+++ b/src/H5ADUtils.cpp
@@ -88,7 +88,6 @@ namespace H5AD
 
 		if (mdd.size.size() == 2)
 			
-
 		if(optimize_storage_size)
 		{
 			auto sizeOfT = sizeof(T);
@@ -255,9 +254,6 @@ namespace H5AD
 		}
 	}
 
-	
-	
-
 	template<typename T>
 	void LoadDataAs(H5::Group& group, LoaderInfo &datasetInfo, bool optimize_storage_size = false, bool allow_lossy_storage = false)
 	{
@@ -269,7 +265,6 @@ namespace H5AD
 		std::vector<std::uint32_t> indptr;
 		std::vector<biovault::bfloat16_t> bf16data;
 		
-
 		if(!std::numeric_limits<T>::is_specialized)
 		{
 			// bfloat16
@@ -947,11 +942,9 @@ namespace H5AD
 	}
 
 
-	
 	template<typename numericalMetaDataType>
 	void LoadSampleNamesAndMetaData(H5::Group& group, LoaderInfo& loaderInfo)
 	{
-
 		static_assert(std::is_same<numericalMetaDataType, float>::value, "");
 		auto nrOfObjects = group.getNumObjs();
 
@@ -1006,8 +999,6 @@ namespace H5AD
 				}
 				if (itemsAreColors)
 				{
-
-					
 					int options = 2;
 					for(int option =0; option < options; ++option)
 					{
@@ -1298,7 +1289,7 @@ namespace H5AD
 									}
 									else
 									{
-										// multi-dimensiona,  only 2 supported for now
+										// multi-dimensional,  only 2 supported for now
 										H5Utils::MultiDimensionalData<float> mdd;
 
 										if (H5Utils::read_multi_dimensional_data(dataSet, mdd))

--- a/src/H5ADUtils.h
+++ b/src/H5ADUtils.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "H5Utils.h"
 
 #include "PointData/PointData.h"

--- a/src/H5ADUtils.h
+++ b/src/H5ADUtils.h
@@ -26,6 +26,8 @@ namespace H5AD
 
 	std::string LoadIndexStrings(H5::Group& group, std::vector<QString>& result);
 
+	bool ContainsSparseMatrix(H5::Group& group);
+
 	bool LoadSparseMatrix(H5::Group& group, LoaderInfo& loaderInfo);
 
 	bool LoadCategories(H5::Group& group, std::map<std::string, std::vector<QString>>& categories);

--- a/src/H5Utils.cpp
+++ b/src/H5Utils.cpp
@@ -226,10 +226,6 @@ namespace H5Utils
 			return false;
 
 		H5::DataSet dataset = group.openDataSet(name);
-
-		H5::PredType predType = getPredTypeFromDataset(dataset);
-		
-
 		H5::DataSpace dataspace = dataset.getSpace();
 
 		/*
@@ -239,24 +235,22 @@ namespace H5Utils
 		std::size_t totalSize = 1;
 		if (dimensions > 0)
 		{
-
 			std::vector<hsize_t> dimensionSize(dimensions);
 			int ndims = dataspace.getSimpleExtentDims(&(dimensionSize[0]), NULL);
 			for (std::size_t d = 0; d < dimensions; ++d)
-			{
-
 				totalSize *= dimensionSize[d];
-			}
+		}
 
-		}
 		if (dimensions != 1)
-		{
 			return false;
-		}
+
+		H5::PredType predType = getPredTypeFromDataset(dataset);
 		vectorHolder.resize(totalSize);
 		vectorHolder.setPredTypeSpecifier(predType);
+
 		dataset.read(vectorHolder.data(), vectorHolder.H5DataType()); // since vector holder doesn't support all H5::PredType types we ask which one it is compatible with
 		dataset.close();
+
 		return true;
 	}
 

--- a/src/H5Utils.h
+++ b/src/H5Utils.h
@@ -248,7 +248,10 @@ namespace H5Utils
 		return true;
 	}
 
-	
+		inline bool contains_name(H5::Group& group, const std::string& name)
+	{
+		return group.exists(name);
+	}
 
 	bool read_vector(H5::Group& group, const std::string& name, VectorHolder& vectorHolder);
 	

--- a/src/HDF5_AD_Loader.cpp
+++ b/src/HDF5_AD_Loader.cpp
@@ -11,10 +11,10 @@
 #include <QDialogButtonBox>
 #include <QtGlobal>
 
+#include <cassert>
 #include <iostream>
+#include <map>
 #include <set>
-
-#include "DataContainerInterface.h"
 
 #include <PointData/PointData.h>
 
@@ -117,7 +117,7 @@ bool HDF5_AD_Loader::open(const QString& fileName)
  }
 
  
- void LoadProperties(H5::DataSet dataset, H5AD::LoaderInfo &datasetInfo)
+static void LoadProperties(H5::DataSet dataset, H5AD::LoaderInfo &datasetInfo)
  {
 	 auto datasetClass = dataset.getDataType().getClass();
 	 QVariantMap propertyMap;
@@ -142,12 +142,7 @@ bool HDF5_AD_Loader::open(const QString& fileName)
 	
  }
 
-
-
-
-
-
- void LoadProperties(H5::Group &group, H5AD::LoaderInfo &datasetInfo)
+static void LoadProperties(H5::Group &group, H5AD::LoaderInfo &datasetInfo)
  {
 	 QString name = group.getObjName().c_str();
 	 if (name.isEmpty())
@@ -334,7 +329,6 @@ bool HDF5_AD_Loader::load(int storageType)
 			}
 		}
 
-
 		std::set<std::string> objectsToProcess;
 
 		QString pointDatasetLabel;
@@ -353,7 +347,6 @@ bool HDF5_AD_Loader::load(int storageType)
 			buttonBox->connect(buttonBox, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
 			layout->addWidget(buttonBox, 3, 0, 1, 2);
 
-
 			dialog.setLayout(layout);
 
 			auto result = dialog.exec();
@@ -363,7 +356,6 @@ bool HDF5_AD_Loader::load(int storageType)
 
 			pointDatasetLabel = lineEdit->displayText();
 
-			
 			for (hsize_t i = 0; i < model.rowCount(); ++i)
 			{
 				auto* item = model.item(i, 0);
@@ -377,9 +369,6 @@ bool HDF5_AD_Loader::load(int storageType)
 		Dataset<Points> pointsDataset = H5Utils::createPointsDataset(_core, false,  pointDatasetLabel);
 		pointsDataset->getDataHierarchyItem().setVisible(false);
 	
-		
-		
-		
 		// first load the main data matrix
 		H5AD::LoaderInfo loaderInfo;
 		
@@ -395,12 +384,9 @@ bool HDF5_AD_Loader::load(int storageType)
 			return false;
 		}
 		
-		
-		
 		//_dimensionNames = pointsDataset->getDimensionNames();
 		
 		// now we look for nice to have annotation for the observations in the main data matrix
-		
 		try
 		{
 			auto nrOfObjects = _file->getNumObjs();
@@ -416,7 +402,6 @@ bool HDF5_AD_Loader::load(int storageType)
 					{
 						H5::DataSet h5Dataset = _file->openDataSet(objectName1);
 						H5AD::LoadSampleNamesAndMetaDataFloat(h5Dataset, loaderInfo);
-							
 					}
 					else if (objectType1 == H5G_GROUP)
 					{

--- a/src/HDF5_AD_Loader.h
+++ b/src/HDF5_AD_Loader.h
@@ -15,16 +15,6 @@ namespace mv
 
 class HDF5_AD_Loader 
 {
-	mv::CoreInterface *_core;
-	std::unique_ptr<H5::H5File> _file;
-	std::vector<QString> _dimensionNames;
-	std::vector<QString> _sampleNames;
-	
-	QString _fileName;
-
-	std::string _var_indexName;
-	std::string _obs_indexName;
-	
 public:
 	HDF5_AD_Loader(mv::CoreInterface *core);
 	
@@ -32,4 +22,14 @@ public:
 	const std::vector<QString> &getDimensionNames() const;
 	bool load(int storageType);
 	
+private:
+	mv::CoreInterface* _core = nullptr;
+	std::unique_ptr<H5::H5File> _file = nullptr;
+	std::vector<QString> _dimensionNames = {};
+	std::vector<QString> _sampleNames = {};
+
+	QString _fileName = {};
+
+	std::string _var_indexName = {};
+	std::string _obs_indexName = {};
 };

--- a/src/VectorHolder.h
+++ b/src/VectorHolder.h
@@ -87,6 +87,20 @@ namespace H5Utils
 
 	public:		
 
+		template<typename T>
+		std::vector<T> getVectorAs() const {
+			return std::visit([](const auto& vec) -> std::vector<T> {
+				std::vector<T> result;
+				result.reserve(vec.size());
+
+				for (const auto& element : vec) {
+					result.push_back(static_cast<T>(element));
+				}
+
+				return result;
+				}, _variantOfVectors);
+		}
+
 		template <typename T>
 		const std::vector<T>& getConstVector() const
 		{


### PR DESCRIPTION
Store large sparse data (which would exceed 4GB in memory if stored as dense) as sparse matrices.
This PR uses an experimental API that **will** be subject to change. But in order to load otherwise to large hdf5 files, we introduce it here for the time being.