### PR TITLE
Fix Loading properties from "var" can cause crashes when using dimens…

### DIFF
--- a/src/HDF5_AD_Loader.cpp
+++ b/src/HDF5_AD_Loader.cpp
@@ -227,7 +227,7 @@ static void LoadProperties(H5::Group &group, H5AD::LoaderInfo &datasetInfo)
 									 label += " (label)";
 									 if (labels.size())
 									 {
-										 filterValues(labels, datasetInfo._selectedDimensionsLUT);
+										 // it shouldn't be needed to filter the labels since they are based on the values which where already filtered.
 										 propertyMap[label] = labels;
 									 }
 								 }


### PR DESCRIPTION
…ion selection #32

Fix Loading properties from "var" can cause crashes when using dimension selection #32